### PR TITLE
Fix travis and coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 *egg-info
 .DS_store
 .cache
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ cache: pip
 install:
   - pip install -e .
   - pip install -r requirements.txt
-  - pip install pytest
-  - pip install codecov
+  - pip install pytest pytest-cov codecov
 
 script: py.test --cov=./
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,50 @@
 
 language: python
+
+# Run the tests on the following python versions
+
 python:
   - 2.7
+  - 3.6
+  - 3.6-dev
+
+# Allow tests on the 3.6-dev version to fail.
+# Don't wait for tests on 3.6-dev to finish before
+# reporting success.
+
+matrix:
+    allow_failures:
+        - python: 3.6-dev 
+    fast_finish: true
+
+# Cache all the pip dependencies on travis for faster builds
+
 cache: pip
+
+# Setting sudo to false will run the job on travis's 
+# containerised infrastructure which may be slightly faster.
+
+sudo: false
+
+# When pulling the repo from git, only pull the three most
+# recent commits, for speed.
+
+git:
+    depth: 3
+
+# Install the govukurllookup package locally, its dependencies,
+# and the test modules.
 
 install:
   - pip install -e .
   - pip install -r requirements.txt
   - pip install pytest pytest-cov codecov
 
-script: py.test --cov=./
+# Run the tests verbosely (-v) and produce a coverage report
+# in the local folder.
+
+script: py.test -v --cov=./
+
+# Call codecov to send the coverage report to codecov.io
 
 after_success: codecov

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='govukurllookup',
       author_email='matthew.upson@digital.cabinet-office.gov.uk',
       license='MIT',
       zip_safe=False,
-      install_requires=['pandas']
+      install_requires=['pandas', 'beautifulsoup4']
      )


### PR DESCRIPTION
* Expand testing on travis to python 3.6 (and 3.6-dev).
* Install pytest-cov in .travis.yml and create coverage reports.
* Call `codecov` to upload coverage reports to codecov.io. 
* Add beautifulsoup to install_requires (so it will be installed when the govukurllookup module is installed).