### PR TITLE
Improve text handling in extract_page

### DIFF
--- a/govukurllookup.py
+++ b/govukurllookup.py
@@ -108,21 +108,14 @@ def extract_text(page):
 
     try:
 
-        page_path = safeget(page, 'base_path').encode('utf-8').strip()
+        page_path = safeget(page, 'base_path').strip()
         page_title = safeget(page, 'title')
         page_desc = safeget(page, 'description')
 
         page_body = safeget(page, 'details', 'body')
-
-        if page_body is None:
-            page_body = unicode("", "utf-8")
-
         page_parts = safeget(page, 'details', 'parts')
 
-        if page_parts is None:
-            page_parts = unicode("", "utf-8")
-
-        page_text = page_body + page_parts
+        page_text = (page_body or "") + (page_parts or "")
 
         soup = BeautifulSoup(page_text, 'html.parser')
          
@@ -133,7 +126,7 @@ def extract_text(page):
             
         # Concatenate the unicode text fields including all text from soup
         
-        txt = u' '.join((page_title, page_desc, soup.getText())).encode('utf-8').strip()
+        txt = ' '.join((page_title, page_desc, soup.getText())).strip()
         
         # Format string by replacing tabs, new lines and commas
         

--- a/tests/test_urllookup.py
+++ b/tests/test_urllookup.py
@@ -4,7 +4,6 @@
 
 import pytest
 import requests
-import sys
 from govukurllookup import api_lookup, govukurls
 import pandas as pd
 
@@ -88,7 +87,6 @@ class TestGovukurls(object):
 
         # TODO: test a redirect url
 
-    @pytest.mark.skipif(sys.version_info >= (3,6), reason="requires python 2.7")
     def test_extract_text(self):
         """
         Test the extract_text() method.


### PR DESCRIPTION
Don't encode strings to bytes, to avoid some code complexity. Also,
remove the use of unicode, and replace it with a empty string.