### PR TITLE
Make the Content Store configurable

### DIFF
--- a/tests/test_urllookup.py
+++ b/tests/test_urllookup.py
@@ -68,7 +68,7 @@ class TestGovukurls(object):
 
         expected = requests.get(expected_url).json()
 
-        assert api_lookup(self.urlsclass.dedupurls[0]) == expected
+        assert api_lookup(self.urlsclass.dedupurls[0], 'https://www.gov.uk/api/content') == expected
 
     @pytest.mark.skipif(not is_connected(), reason="Cannot connect to gov.uk")
     def test_lookup_method(self):


### PR DESCRIPTION
https://www.gov.uk/api/content is one way of accessing the GOV.UK
Content Store service, but it's not the only way.

To allow this class to be used to talk to the draft content store,
which isn't publically accessible, add an optional argument that can
be used to specify the URL of the Content Store.

The default behaviour should remain the same.